### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ allprojects {
 
 ```
 dependencies {
-	compile 'com.github.linger1216:labelview:v1.1.2'
+	implementation 'com.github.linger1216:labelview:v1.1.2'
 }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.